### PR TITLE
Updated 'parsimonious' dependency to stop getting an error while using Python >= 3.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     install_requires=[
         'click~=7.1.2',
         'psutil~=5.7.0',
-        'parsimonious~=0.8.1',
+        'parsimonious~=0.9.0',
     ],
     packages=find_packages(),
     python_requires='>=3.6, <4',


### PR DESCRIPTION
The issue is mentioned here: https://github.com/erikrose/parsimonious/issues/225. It's been fixed since version 0.9.0, so I've updated the dependency. 