### PR TITLE
Fix: Remove trailing whitespace before calling NodeSetParser.parse()

### DIFF
--- a/vfio_isolate/nodeset.py
+++ b/vfio_isolate/nodeset.py
@@ -65,6 +65,7 @@ class NodeSet:
         elif isinstance(initial, set):
             self.nodes = initial
         elif isinstance(initial, str):
+            initial = initial.rstrip()
             self.nodes = NodeSetParser.parse(initial)
         else:
             raise Exception("unable to initialize NodeSet")


### PR DESCRIPTION
Remove any trailing whitespace before calling NodeSetParser,parse()
- Exceptions if there is a trailing linefeed (\n). CPUNodeSet(f.read()) returns trailing linefeed

Fixes #12 