### PR TITLE
Add cpu governor line to example script

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ enable_isolation () {
 	vfio-isolate \
 		-u $UNDOFILE \
 		drop-caches \
+		cpu-governor performance \
 		cpuset-modify --cpus C$HCPUS /system.slice \
 		cpuset-modify --cpus C$HCPUS /user.slice \
 		compact-memory \


### PR DESCRIPTION
It's mentioned in the readme, and it's a very common thing to do when optimizing VM performance. So, I think it should be included in example script

I may or may not have failed to notice lack of cpu governor setting after copying the script :) Took some time to figure out